### PR TITLE
Метод SupportingFunction::parseArticleText объявлен статическим.

### DIFF
--- a/common/SupportingFunction.php
+++ b/common/SupportingFunction.php
@@ -55,7 +55,7 @@ class SupportingFunction
     /**
      * Парсинг поста - картинки, блоки, видео
      */
-    public function parseArticleText()
+    public static function parseArticleText()
     {
         $articleID = get_the_ID();
         $post = get_post($articleID);


### PR DESCRIPTION
Исправлено: метод SupportingFunction::parseArticleText вызывается только статически, хотя таким НЕ объявлен.