### PR TITLE
Convert {} to [] for PHP 7.4.

### DIFF
--- a/common/contents/ContentsPost.php
+++ b/common/contents/ContentsPost.php
@@ -147,7 +147,7 @@ class ContentsPost
         $level = array();
         foreach ($tags as $k => $val) {
             // class
-            if ($val{0} === '.') {
+            if ($val[0] === '.') {
                 $val = substr($val, 1);
                 $link = &$class_patt;
             } // html tag
@@ -194,7 +194,7 @@ class ContentsPost
         $level = array();
         foreach ($tags as $k => $val) {
             // class
-            if ($val{0} === '.') {
+            if ($val[0] === '.') {
                 $val = substr($val, 1);
                 $link = &$class_patt;
             } // html tag


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_curly_braces_array_access